### PR TITLE
Nav link hover

### DIFF
--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -33,6 +33,35 @@
     color: green;
 }
 
+//underlining hover effect for nav links
+.nav-link-hover {
+    display: inline-block;
+    position: relative;
+    color: green;
+    text-decoration: none;
+}
+
+.nav-link-hover::after {
+    content: '';
+    position: absolute;
+    width: 100%;
+    transform: scaleX(0);
+    height: 2px;
+    bottom: 0;
+    left: 0;
+    background-color: green;
+    transform-origin: bottom right;
+    transition: transform 0.25s ease-out;
+}
+
+.nav-link-hover:hover::after {
+    transform: scaleX(1);
+    transform-origin: bottom left;
+
+}
+
+// Media Queries
+
 /* Extra small devices (phones, 600px and down) */
 @media only screen and (max-width: 600px) {
     .navlinks {

--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -51,7 +51,7 @@
     left: 0;
     background-color: green;
     transform-origin: bottom right;
-    transition: transform 0.25s ease-out;
+    transition: transform 0.15s ease-out;
 }
 
 .nav-link-hover:hover::after {

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -4,11 +4,11 @@
   </div>
   <div class="navlinks">
     <ul>
-      <li>About</li>
-      <li>Experience</li>
-      <li>Work</li>
-      <li>Contact</li>
-      <li>CV</li>
+      <li><a href="#about" class="nav-link-hover">About</a></li>
+      <li><a href="#experience" class="nav-link-hover">Experience</a></li>
+      <li><a href="#work" class="nav-link-hover">Work</a></li>
+      <li><a href="#contact" class="nav-link-hover">Contact</a></li>
+      <li><a href="#CV" class="nav-link-hover">CV</a></li>
     </ul>
   </div>
 </div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,6 +1,6 @@
 <div class="navbar-container">
   <div class="logo">
-    <%= image_tag "CwLogo.png" , class:"logo"%>
+    <a href="#home" class="nav-link-hover"><%= image_tag "CwLogo.png" , class:"logo"%></a>
   </div>
   <div class="navlinks">
     <ul>


### PR DESCRIPTION
hover effect added to links on the navbar
Navbar links now wrapped within <a>tags within parent <li> element
Text decoration set to none on links to avoid premature/double underlining
 